### PR TITLE
全テーブルにCompanyを持つ。紹介者をApplicationに移動

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -17,8 +17,6 @@ definitions:
     description: "システムにログインするユーザー。管理者と社員を想定"
     type: "object"
     properties:
-      company:
-        $ref: '#/definitions/Company'
 
   Incentive:
     description: "社員が紹介した求人が内定すると貯まるインセンティブ。"
@@ -48,19 +46,13 @@ definitions:
       status: 
         description: "#応募/面談/内定/削除 などのステータス"
         $ref: '#/definitions/Status'
-      company:
-        $ref: '#/definitions/Company'
 
   Applicant:
     type: "object"
     description: "求人に応募する人"
     properties:
-      company:
-        $ref: '#/definitions/Company'
 
   Status:
     type: "object"
     description: "#応募/面談/内定/削除 などのステータス"
     properties:
-      company:
-        $ref: '#/definitions/Company'

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -39,22 +39,28 @@ definitions:
       job: 
         description: "求人情報"
         $ref: '#/definitions/Job'
+      introducer: 
+        description: "求人紹介した社員"
+        $ref: '#/definitions/User'
       applicant:
         description: "求人に応募する人" 
         $ref: '#/definitions/Applicant'        
       status: 
         description: "#応募/面談/内定/削除 などのステータス"
         $ref: '#/definitions/Status'
+      company:
+        $ref: '#/definitions/Company'
 
   Applicant:
     type: "object"
     description: "求人に応募する人"
     properties:
-      introducer: 
-        description: "求人紹介した社員"
-        $ref: '#/definitions/User'
+      company:
+        $ref: '#/definitions/Company'
 
   Status:
     type: "object"
     description: "#応募/面談/内定/削除 などのステータス"
     properties:
+      company:
+        $ref: '#/definitions/Company'


### PR DESCRIPTION
DBの修正に合わせて、swaggerの定義も修正する
修正点は２点
- 全テーブルにCompanyを持つ。
- 紹介者をApplicantからApplicationに移動

詳細は以下を参照のこと
https://github.com/nuno929/team-maker-back/pull/5