### PR TITLE
求人レコード取得APIの仕様 を追加

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -59,7 +59,6 @@ paths:
                         type: string
                         example: ページ種別に依存しないコンテンツサンプル
                       pageable_content:
-                        type: object
                         properties:
                           type:
                             title: コンテンツのタイプ
@@ -67,79 +66,83 @@ paths:
                             enum: [job, facilities, wysiwyg]
                             example: job
                           record:
-                            type: object
-                            properties:
-                              id:
-                                title: コンテンツのID
-                                type: number
-                                example: 1
-                              employment_category_id:
-                                title: 就業形態
-                                type: number
-                                example: 1
-                              code:
-                                title: 管理用コード
-                                type: number
-                                example: 72
-                              name:
-                                title: 求人のタイトル
-                                type: string
-                                example: Jerrod Jenkins
-                              job_content:
-                                title: 業務内容
-                                type: string
-                                example: Magnam autem tempora voluptatem numquam. In nulla ut animi in et nulla.
-                              contract_period:
-                                type: object
-                                properties:
-                                  finished_at:
-                                    title: 契約期間
-                                    type: string
-                                    example:
-                              welfare:
-                                title: 福利厚生
-                                type: string
-                                example: ◇ 労災保険
-                              industry:
-                                type: object
-                                properties:
-                                  industry:
-                                    title: 業界
-                                    type: string
-                                    example: 
-                                  occupation:
-                                    title: 職業
-                                    type: string
-                                    example:
-                              work_datetime:
-                                type: object
-                                properties:
-                              salary:
-                                type: object
-                                properties: 
-                                  hourly:
-                                    title: 時給
-                                    type: string
-                                    example:
-                              place:
-                                title: 勤務地
-                                type: string
-                                example: 315 Torp Cliffs Apt. 455
-                              info:
-                                type: object
-                                properties:
-                              published_at:
-                                title: 掲載開始日
-                                type: string
-                                example: 2020-09-04 15:25:07
-                              expired_at:
-                                title: 有効期限
-                                type: string
-                                example: expired_at            
+                            $ref: '#/components/schemas/Job'
                   released_at:
                     title: 公開日
                     type: string
                     example: 2020-10-04 15:25:07
+components:
+  schemas: # スキーマオブジェクトの定義
+    Job: # モデル名
+      type: object
+      properties:
+        id:
+          title: コンテンツのID
+          type: number
+          example: 1
+        employment_category_id:
+          title: 就業形態
+          type: number
+          example: 1
+        code:
+          title: 管理用コード
+          type: number
+          example: 72
+        name:
+          title: 求人のタイトル
+          type: string
+          example: Jerrod Jenkins
+        job_content:
+          title: 業務内容
+          type: string
+          example: Magnam autem tempora voluptatem numquam. In nulla ut animi in et nulla.
+        contract_period:
+          type: object
+          properties:
+            finished_at:
+              title:
+              type:
+              example:
+        welfare:
+          title: 福利厚生
+          type: string
+          example: ◇ 労災保険
+        industry:
+          type: object
+          properties:
+            industry:
+              title: 業界
+              type: string
+              example:
+            occupation:
+              title: 職業
+              type: string
+              example:
+        work_datetime:
+          type: object
+          properties:
+        salary:
+          type: object
+          properties:
+              hourly:
+                title: 時給
+                type: string
+                example:
+        place:
+          title: 勤務地
+          type: string
+          example: 315 Torp Cliffs Apt. 455
+        info:
+          type: object
+          properties:
+        published_at:
+          title: 掲載開始日
+          type: string
+          example: 2020-09-04 15:25:07
+        expired_at:
+          title: 有効期限
+          type: string
+          example: expired_at                                
 definitions:
   Company:
     description: "求人企業情報"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,4 +1,4 @@
-swagger: "2.0"
+openapi: "3.0.2"
 info:
   description: "これはTEAM-MAKERに関するAPIです。"
   version: "0.0.1"
@@ -6,7 +6,80 @@ info:
   termsOfService: "http://teammaker.com" # 仮定義
   contact:
     email: "system@teammaker.info"
-paths: # TODO: 後で定義する
+# paths: # TODO: 後で定義する
+servers:
+  - url: "http://localhost:8888"
+    description: ローカルサーバ
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+paths:
+  "/api/v1/page/{id}":
+    get:
+      summary: "求人レコードの取得エンドポイント"
+      description: "求人レコードの取得エンドポイント"
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: "ページ詳細"
+          content:
+            "application/json":
+              schema:
+                type: object
+                required:
+                  - id
+                  - name
+                properties:
+                  id:
+                    title: ページID
+                    type: number
+                    readOnly: true
+                    example: 1
+                  company_id:
+                    title: 会社ID
+                    type: string
+                    example: 2
+                  meta:
+                    title: メタタグ
+                    type: json
+                    example: {}
+                  content:
+                    title: コンテンツ
+                    type: string
+                    example: ページ種別に依存しないコンテンツ
+                  job:
+                    title: 求人
+                    type: json
+                    example: { 
+                      id: 1, 
+                      employment_category_id: 1,
+                      code: 管理用コード,
+                      name: 港区で働く訪問看護師,
+                      job_content: 業務内容,
+                      contract_period: {},
+                      welfare: 福利厚生,
+                      industry: {},
+                      work_datetime: {},
+                      salary: {},
+                      place: {},
+                      info: {},
+                      published_at: 2020-09-04 15:25:07,
+                      expired_at: 2020-11-04 15:25:07
+                    }
+                  released_at:
+                    title: 公開日
+                    type: string
+                    example: 2020-10-04 15:25:07
 definitions:
   Company:
     description: "求人企業情報"
@@ -28,24 +101,24 @@ definitions:
     description: "求人情報"
     properties:
       company:
-        $ref: '#/definitions/Company'
+        $ref: "#/definitions/Company"
 
   Application:
     type: "object"
     description: "社員から紹介された求人応募情報"
     properties:
-      job: 
+      job:
         description: "求人情報"
-        $ref: '#/definitions/Job'
-      introducer: 
+        $ref: "#/definitions/Job"
+      introducer:
         description: "求人紹介した社員"
-        $ref: '#/definitions/User'
+        $ref: "#/definitions/User"
       applicant:
-        description: "求人に応募する人" 
-        $ref: '#/definitions/Applicant'        
-      status: 
+        description: "求人に応募する人"
+        $ref: "#/definitions/Applicant"
+      status:
         description: "#応募/面談/内定/削除 などのステータス"
-        $ref: '#/definitions/Status'
+        $ref: "#/definitions/Status"
 
   Applicant:
     type: "object"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -23,71 +23,73 @@ paths:
           content:
             "application/json":
               schema:
-                type: object
-                required:
-                  - id
-                  - name
-                properties:
-                  id:
-                    title: ページID
-                    type: number
-                    readOnly: true
-                    example: 1
-                  company:
-                    type: object
-                    properties:
-                      name:
-                        title: 会社名
-                        type: string
-                        example: サンプル会社
-                      unique_id:
-                        title: 会社ID
-                        type: string
-                        example: 5e55sss2dc291d
-                  meta:
-                    type: object
-                    properties:
-                      title:
-                        title: タイトル
-                        type: string
-                        example: サンプルタイトル
-                  content:
-                    type: object
-                    properties:
-                      common_content:
-                        title: ページ種別に依存しないコンテンツ
-                        type: string
-                        example: ページ種別に依存しないコンテンツサンプル
-                      pageable_content:
-                        properties:
-                          type:
-                            title: コンテンツのタイプ
-                            type: string
-                            enum: [job, facilities, wysiwyg]
-                            example: job
-                          record:
-                            $ref: '#/components/schemas/Job'
-                  released_at:
-                    title: 公開日
-                    type: string
-                    example: 2020-10-04 15:25:07
+                $ref: "#/components/schemas/Page"
 components:
-  schemas: # スキーマオブジェクトの定義
-    Job: # モデル名
+  schemas:
+    Page:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          title: ページID
+          type: number
+          readOnly: true
+          example: 1
+        company:
+          $ref: "#/components/schemas/Company"
+        meta:
+          type: object
+          properties:
+            title:
+              title: タイトル
+              type: string
+              example: サンプルタイトル
+        content:
+          type: object
+          properties:
+            common_content:
+              title: ページ種別に依存しないコンテンツ
+              type: string
+              example: ページ種別に依存しないコンテンツサンプル
+            pageable_content:
+              title: ポリモーフィック
+              type: object
+              properties:
+                type:
+                  title: コンテンツタイプ
+                  type: string
+                  enum: [job]
+                  example: job
+                record:
+                  $ref: "#/components/schemas/Job"
+        released_at:
+          title: 公開日
+          type: string
+          example: 2020-10-04 15:25:07
+    Job:
       type: object
       properties:
         id:
           title: コンテンツのID
           type: number
           example: 1
-        employment_category_id:
-          title: 就業形態
-          type: number
-          example: 1
+        employment_category:
+          type: object
+          properties:
+            id:
+              title: 雇用タイプのID
+              type: number
+              example: 1
+            name:
+              title: 雇用タイプ
+              type: string
+              example: 正社員  
         code:
           title: 管理用コード
-          type: number
-          example: 72
+          type: string
+          example: 476828240
         name:
           title: 求人のタイトル
           type: string
@@ -99,10 +101,6 @@ components:
         contract_period:
           type: object
           properties:
-            finished_at:
-              title:
-              type:
-              example:
         welfare:
           title: 福利厚生
           type: string
@@ -124,10 +122,10 @@ components:
         salary:
           type: object
           properties:
-              hourly:
-                title: 時給
-                type: string
-                example:
+            hourly:
+              title: 時給
+              type: string
+              example:
         place:
           title: 勤務地
           type: string
@@ -142,54 +140,15 @@ components:
         expired_at:
           title: 有効期限
           type: string
-          example: expired_at                                
-definitions:
-  Company:
-    description: "求人企業情報"
-    type: "object"
-    properties:
-
-  User:
-    description: "システムにログインするユーザー。管理者と社員を想定"
-    type: "object"
-    properties:
-
-  Incentive:
-    description: "社員が紹介した求人が内定すると貯まるインセンティブ。"
-    type: "object"
-    properties:
-
-  Job:
-    type: "object"
-    description: "求人情報"
-    properties:
-      company:
-        $ref: "#/definitions/Company"
-
-  Application:
-    type: "object"
-    description: "社員から紹介された求人応募情報"
-    properties:
-      job:
-        description: "求人情報"
-        $ref: "#/definitions/Job"
-      introducer:
-        description: "求人紹介した社員"
-        $ref: "#/definitions/User"
-      applicant:
-        description: "求人に応募する人"
-        $ref: "#/definitions/Applicant"
-      status:
-        description: "#応募/面談/内定/削除 などのステータス"
-        $ref: "#/definitions/Status"
-
-  Applicant:
-    type: "object"
-    description: "求人に応募する人"
-    properties:
-
-  Status:
-    type: "object"
-    description: "#応募/面談/内定/削除 などのステータス"
-    properties:
-
+          example: expired_at
+    Company:
+      type: object
+      properties:
+        name:
+          title: 会社名
+          type: string
+          example: サンプル会社
+        unique_id:
+          title: 会社ID
+          type: string
+          example: 5e55sss2dc291d

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -19,8 +19,8 @@ components:
 paths:
   "/api/v1/page/{id}":
     get:
-      summary: "求人レコードの取得エンドポイント"
-      description: "求人レコードの取得エンドポイント"
+      summary: "ページコンテンツ取得エンドポイント"
+      description: "ページコンテンツ取得エンドポイント"
       security:
         - bearerAuth: []
       parameters:
@@ -55,26 +55,37 @@ paths:
                     example: {}
                   content:
                     title: コンテンツ
-                    type: string
-                    example: ページ種別に依存しないコンテンツ
-                  job:
-                    title: 求人
                     type: json
-                    example: { 
-                      id: 1, 
-                      employment_category_id: 1,
-                      code: 管理用コード,
-                      name: 港区で働く訪問看護師,
-                      job_content: 業務内容,
-                      contract_period: {},
-                      welfare: 福利厚生,
-                      industry: {},
-                      work_datetime: {},
-                      salary: {},
-                      place: {},
-                      info: {},
-                      published_at: 2020-09-04 15:25:07,
-                      expired_at: 2020-11-04 15:25:07
+                    example: {
+                      common_content: ページ種別に依存しないコンテンツ,
+                      pageable_content: {
+                        type: job,
+                        record: {
+                          id: 1,
+                          employment_category_id: 1,
+                          code: 72,
+                          name: Jerrod Jenkins,
+                          job_content: Magnam autem tempora voluptatem numquam. In nulla ut animi in et nulla. Et voluptatum sint necessitatibus et sint non. Ipsum assumenda earum aut debitis et ullam.,
+                          contract_period: {
+                            finished_at: 2020-09-04 15:25:07
+                          },
+                          welfare: In doloremque et sequi quo voluptatem maiores qui. Dolorem rem et voluptatibus temporibus vel est. Vitae est ab non quasi deserunt et.,
+                          industry: {
+                            industry: "",
+                            occupation: "",
+                          },
+                          work_datetime: {},
+                          salary: {
+                            hourly: ""
+                          },
+                          place: {
+                            address: 315 Torp Cliffs Apt. 455
+                          },
+                          info: {},
+                          published_at: 2020-09-04 15:25:07,
+                          expired_at: 2020-11-04 15:25:07
+                        }
+                      }
                     }
                   released_at:
                     title: 公開日

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -40,6 +40,9 @@ paths:
                   meta:
                     type: object
                     properties:
+                      title: タイトル
+                      type: string
+                      example: タイトル
                   content:
                     type: object
                     properties:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -6,7 +6,6 @@ info:
   termsOfService: "http://teammaker.com" # 仮定義
   contact:
     email: "system@teammaker.info"
-# paths: # TODO: 後で定義する
 servers:
   - url: "http://localhost:8888"
     description: ローカルサーバ
@@ -50,43 +49,93 @@ paths:
                     type: string
                     example: 2
                   meta:
-                    title: メタタグ
-                    type: json
-                    example: {}
+                    type: object
+                    properties:
                   content:
-                    title: コンテンツ
-                    type: json
-                    example: {
-                      common_content: ページ種別に依存しないコンテンツ,
-                      pageable_content: {
-                        type: job,
-                        record: {
-                          id: 1,
-                          employment_category_id: 1,
-                          code: 72,
-                          name: Jerrod Jenkins,
-                          job_content: Magnam autem tempora voluptatem numquam. In nulla ut animi in et nulla. Et voluptatum sint necessitatibus et sint non. Ipsum assumenda earum aut debitis et ullam.,
-                          contract_period: {
-                            finished_at: 2020-09-04 15:25:07
-                          },
-                          welfare: In doloremque et sequi quo voluptatem maiores qui. Dolorem rem et voluptatibus temporibus vel est. Vitae est ab non quasi deserunt et.,
-                          industry: {
-                            industry: "",
-                            occupation: "",
-                          },
-                          work_datetime: {},
-                          salary: {
-                            hourly: ""
-                          },
-                          place: {
-                            address: 315 Torp Cliffs Apt. 455
-                          },
-                          info: {},
-                          published_at: 2020-09-04 15:25:07,
-                          expired_at: 2020-11-04 15:25:07
-                        }
-                      }
-                    }
+                    type: object
+                    properties:
+                      common_content:
+                        title: ページ種別に依存しないコンテンツ
+                        type: string
+                        example: ページ種別に依存しないコンテンツサンプル
+                      pageable_content:
+                        type: object
+                        properties:
+                          type:
+                            title: コンテンツのタイプ
+                            type: string
+                            enum: [job, facilities, wysiwyg]
+                            example: job
+                          record:
+                            type: object
+                            properties:
+                              id:
+                                title: コンテンツのID
+                                type: number
+                                example: 1
+                              employment_category_id:
+                                title: 就業形態
+                                type: number
+                                example: 1
+                              code:
+                                title: 管理用コード
+                                type: number
+                                example: 72
+                              name:
+                                title: 求人のタイトル
+                                type: string
+                                example: Jerrod Jenkins
+                              job_content:
+                                title: 業務内容
+                                type: string
+                                example: Magnam autem tempora voluptatem numquam. In nulla ut animi in et nulla.
+                              contract_period:
+                                type: object
+                                properties:
+                                  finished_at:
+                                    title: 契約期間
+                                    type: string
+                                    example:
+                              welfare:
+                                title: 福利厚生
+                                type: string
+                                example: ◇ 労災保険
+                              industry:
+                                type: object
+                                properties:
+                                  industry:
+                                    title: 業界
+                                    type: string
+                                    example: 
+                                  occupation:
+                                    title: 職業
+                                    type: string
+                                    example:
+                              work_datetime:
+                                type: object
+                                properties:
+                              salary:
+                                type: object
+                                properties: 
+                                  hourly:
+                                    title: 時給
+                                    type: string
+                                    example:
+                              place:
+                                title: 勤務地
+                                type: string
+                                example: 315 Torp Cliffs Apt. 455
+                              info:
+                                type: object
+                                properties:
+                              published_at:
+                                title: 掲載開始日
+                                type: string
+                                example: 2020-09-04 15:25:07
+                              expired_at:
+                                title: 有効期限
+                                type: string
+                                example: expired_at            
                   released_at:
                     title: 公開日
                     type: string
@@ -140,3 +189,4 @@ definitions:
     type: "object"
     description: "#応募/面談/内定/削除 などのステータス"
     properties:
+

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -33,16 +33,24 @@ paths:
                     type: number
                     readOnly: true
                     example: 1
-                  company_id:
-                    title: 会社ID
-                    type: string
-                    example: 2
+                  company:
+                    type: object
+                    properties:
+                      name:
+                        title: 会社名
+                        type: string
+                        example: サンプル会社
+                      unique_id:
+                        title: 会社ID
+                        type: string
+                        example: 5e55sss2dc291d
                   meta:
                     type: object
                     properties:
-                      title: タイトル
-                      type: string
-                      example: タイトル
+                      title:
+                        title: タイトル
+                        type: string
+                        example: サンプルタイトル
                   content:
                     type: object
                     properties:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -6,28 +6,17 @@ info:
   termsOfService: "http://teammaker.com" # 仮定義
   contact:
     email: "system@teammaker.info"
-servers:
-  - url: "http://localhost:8888"
-    description: ローカルサーバ
-components:
-  securitySchemes:
-    bearerAuth:
-      type: http
-      scheme: bearer
-      bearerFormat: JWT
 paths:
-  "/api/v1/page/{id}":
+  "/api/v1/page/{slug}":
     get:
       summary: "ページコンテンツ取得エンドポイント"
       description: "ページコンテンツ取得エンドポイント"
-      security:
-        - bearerAuth: []
       parameters:
         - in: path
-          name: id
+          name: slug
           required: true
           schema:
-            type: integer
+            type: string
       responses:
         "200":
           description: "ページ詳細"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -54,7 +54,7 @@ components:
               type: string
               example: ページ種別に依存しないコンテンツサンプル
             pageable_content:
-              title: ポリモーフィック
+              title: ポリモーフィック関連で結びつくモデルがセットされる。各モデルのスキーマは、別プロパティに詳述する。 ex) jobが紐づく場合は、jobになる
               type: object
               properties:
                 type:


### PR DESCRIPTION
### 変更内容

https://github.com/TEAMMAKER-dev/team-maker-back/issues/106 のAPIの仕様を追加しました。

https://www.chatwork.com/#!rid176972051-1285139273560924160 でコメントいただいた内容は反映していますが、不足点や認識異なるところがあるようでしたらコメントいただけると幸いです。

いくつか懸念、疑問点があったので、少し質問させていただきたいです 🙏 

### 質問

- いったん テーブル（pages、jobs）が持っているデータをAPIで返すような感じの想定をしていますが、APIで返す際に不要なものがあったら教えていただきたいです。例えば、 metaカラム（メタタグの内容を記載する）に格納されてるデータがいまいちイメージつかなかったのですが、必要ではないなどあったりしますでしょうか。

- また、compay_id などを返すようになっている部分もありますが、こちらは加工して comany オブジェクトにする必要などあったりしますでしょうか？（front側では、companyのnameが必要だったりするかと思ったりしている感じです）

- タイプ（ポリモーフィックリレーションのタイプ。例えば、job、施設情報など）ごとに、レスポンスの中身（コンテンツ）は変わる想定でしょうか？このPRでいうところの `pageable_content ` の `type` 部分です。タイプが変わると、`record ` オブジェクトの内容が変わりそうかと思っていて、変わりそうな場合、エンドポイント分けたほうが良さそうでは？と思ったりしています。（変わらない場合は、そのままで大丈夫そうに思うのですが、変わりそうかと思っています。認識が異なりそうであれば教えていただけると幸いです）


お手数お掛けいたしますがよろしくおねがいします 🙏 
