### PR TITLE
求人レコード取得APIのゲットパラメータについて #15

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -50,9 +50,9 @@ paths:
                   title: 求人のID
                   type: number
                   example: 1
-                refer_user_id:
-                  title: 紹介したユーザーのID
-                  type: number
+                refer_code:
+                  title: 紹介したユーザーを特定するコード
+                  type: string
                   example: 1
       responses:
         '201':

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3,7 +3,7 @@ info:
   description: "これはTEAM-MAKERに関するAPIです。"
   version: "0.0.1"
   title: "TEAM-MAKER API"
-  termsOfService: "http://teammaker.com"
+  termsOfService: "http://teammaker.com" # 仮定義
   contact:
     email: "system@teammaker.info"
 paths:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3,7 +3,7 @@ info:
   description: "これはTEAM-MAKERに関するAPIです。"
   version: "0.0.1"
   title: "TEAM-MAKER API"
-  termsOfService: "http://teammaker.com" # 仮定義
+  termsOfService: "http://teammaker.com"
   contact:
     email: "system@teammaker.info"
 paths:
@@ -18,8 +18,7 @@ paths:
           schema:
             type: string
         - in: query
-          name: refer_user_id
-          required: true
+          name: refer_code
           schema:
             type: string
       responses:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -17,6 +17,11 @@ paths:
           required: true
           schema:
             type: string
+        - in: query
+          name: refer_user_id
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           description: "ページ詳細"
@@ -46,7 +51,7 @@ paths:
                   title: 求人のID
                   type: number
                   example: 1
-                user_id:
+                refer_user_id:
                   title: 紹介したユーザーのID
                   type: number
                   example: 1


### PR DESCRIPTION
close #15 

### 変更点

- 求人票が従業員の誰から共有したものであるかを判定するため、ゲットパラメータを追加する想定のため、修正
- いったんuser_idを想定して作成しました

### 確認したいこと

> 従業員IDでも良さそう
セキュリティリスクがあるなら、共有用のコードをランダムに発行する

- やったほうが良さそうな気がしますが、紹介した人にしか共有されないURLだからそんなに気にしなくても良さそうだったりしますかね...

- 共有用のコードをランダムに発行する場合の実装イメージとしては、usersテーブルにunique_idといったカラムを追加して、共有用のコードを保存して、その情報をもとに紹介したユーザーを特定するようなイメージですかね...（ユーザー登録時にランダムで生成されるイメージです）


- `src/app/Http/Controllers/Auth/RegisterController.php` のコードを変更するようなイメージです！
```php
/**
     * Create a new user instance after a valid registration.
     *
     * @param  array  $data
     * @return \App\User
     */
    protected function create(array $data)
    {
        return User::create([
            'name' => $data['name'],
            'email' => $data['email'],
            'refer_unique_id' => 'ランダムに生成' // ここ追加
            'password' => Hash::make($data['password']),
        ]);
    }
```