### PR TITLE
求人ページコンテンツ登録エンドポイントを追加

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -7,6 +7,51 @@ info:
   contact:
     email: "system@teammaker.info"
 paths:
+  "/api/v0/page":
+    post:
+      summary: "求人ページコンテンツ登録エンドポイント"
+      description: "求人ページコンテンツ登録エンドポイント"
+      requestBody:
+        description: job page to create
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                employment_category_id:
+                  title: 雇用タイプのID
+                  type: number
+                  example: 1
+                code:
+                  title: 管理用コード
+                  type: string
+                  example: 1
+                name:
+                  title: 求人のタイトル
+                  type: string
+                  example: 求人のタイトルサンプル
+                job_content:
+                  title: 業務内容
+                  type: string
+                  example: Magnam autem tempora voluptatem numquam. In nulla ut animi in et nulla.
+                welfare:
+                  title: 福利厚生
+                  type: string
+                  example: 労災保険
+                published_at:
+                  title: 掲載開始日
+                  type: string
+                  example: 2020-10-04 15:25:07
+                expired_at:
+                  title: 掲載開始日
+                  type: string
+                  example: 2020-11-04 15:25:07
+      responses:
+        "200":
+          description: "ページ詳細"
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/Page"
   "/api/v0/page/{slug}":
     get:
       summary: "ページコンテンツ取得エンドポイント"


### PR DESCRIPTION
### 変更点

https://github.com/TEAMMAKER-dev/team-maker-back/issues/111 のドキュメントを追加しました

### 確認していただきたいこと

- 前提として、 https://github.com/TEAMMAKER-dev/team-maker-back/issues/111#issuecomment-597050849 のコメントの認識があっているかどうか確認していただけると助かります！:pray:

- ユーザーがログイン済であること前提で叩かれるAPIかと認識しています！間違ってたら教えていただけると助かります！

- 基本的にJobテーブルのカラムの項目をpostするようなイメージで記載していますが、その中でも json型のカラムについて、どういったデータが入るか想定できていないので、教えていただけると幸いです 🙏 （null可になっているのと、プロトタイプで検討中のため、いったん含めないで良さそう、などありましたら教えていただけると幸いです 🙏 ）

  - contract_period
  - industry ｗ
  - work_datetime 
  - salaryr
  - place
  - info

- その他、前提の認識や抜け漏れがありそうな部分がありましたらご指摘いただけると幸いです！ 🙏 